### PR TITLE
minor enhancement: PlayFabResult<TResult> should have base class with non-generic members

### DIFF
--- a/PlayFabSDK/source/PlayFabErrors.cs
+++ b/PlayFabSDK/source/PlayFabErrors.cs
@@ -383,12 +383,16 @@ namespace PlayFab
             return Sb.ToString();
         }
     };
-
-    public class PlayFabResult<TResult> where TResult : PlayFabResultCommon
+    
+    public class PlayFabResultBase
     {
         public PlayFabError Error;
-        public TResult Result;
         public object CustomData;
+    }    
+
+    public class PlayFabResult<TResult> : PlayFabResultBase where TResult : PlayFabResultCommon
+    {
+        public TResult Result;
     }
     
     public delegate void ErrorCallback(PlayFabError error);


### PR DESCRIPTION
I am handling several playfab admin API calls with one Task-centered concurrency manager. I wish I could get to the Error member of PlayFabResult<TResult> regardless of which API I was using--that is, regardless of what TResult is. The point where I'm handling errors could be handling many different PlayFabResult<TResult> types and I'm only able to get to the Error member through reflection.

Here's what it should look like (but I didn't actually build this code to check for dumb mistakes)

I'm not sure `PlayFabResultBase` is a great name, but the name doesn't matter to me.