### PR TITLE
Delete azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,0 @@
-pool:
-  vmImage: 'ubuntu-latest'
-
-trigger:
-- master
-
-extends:
-  template: CSharpResourceTemplate.yml


### PR DESCRIPTION
We can't use the azure-pipelines.yml file in any BuildAll pipelines