### PR TITLE
Fixed instances of CurrentCulture to InvariantCulture

### DIFF
--- a/PlayFabSDK/source/Json/ISerializer.cs
+++ b/PlayFabSDK/source/Json/ISerializer.cs
@@ -71,14 +71,14 @@ namespace PlayFab.Json
                 else if (type == typeof(DateTime))
                 {
                     DateTime output;
-                    var result = DateTime.TryParseExact(valueStr, PlayFabUtil.DefaultDateTimeFormats, CultureInfo.CurrentCulture, _dateTimeStyles, out output);
+                    var result = DateTime.TryParseExact(valueStr, PlayFabUtil.DefaultDateTimeFormats, CultureInfo.InvariantCulture, _dateTimeStyles, out output);
                     if (result)
                         return output;
                 }
                 else if (type == typeof(DateTimeOffset))
                 {
                     DateTimeOffset output;
-                    var result = DateTimeOffset.TryParseExact(valueStr, PlayFabUtil.DefaultDateTimeFormats, CultureInfo.CurrentCulture, _dateTimeStyles, out output);
+                    var result = DateTimeOffset.TryParseExact(valueStr, PlayFabUtil.DefaultDateTimeFormats, CultureInfo.InvariantCulture, _dateTimeStyles, out output);
                     if (result)
                         return output;
                 }
@@ -103,12 +103,12 @@ namespace PlayFab.Json
                 }
                 else if (input is DateTime)
                 {
-                    output = ((DateTime)input).ToString(PlayFabUtil.DefaultDateTimeFormats[PlayFabUtil.DEFAULT_UTC_OUTPUT_INDEX], CultureInfo.CurrentCulture);
+                    output = ((DateTime)input).ToString(PlayFabUtil.DefaultDateTimeFormats[PlayFabUtil.DEFAULT_UTC_OUTPUT_INDEX], CultureInfo.InvariantCulture);
                     return true;
                 }
                 else if (input is DateTimeOffset)
                 {
-                    output = ((DateTimeOffset)input).ToString(PlayFabUtil.DefaultDateTimeFormats[PlayFabUtil.DEFAULT_UTC_OUTPUT_INDEX], CultureInfo.CurrentCulture);
+                    output = ((DateTimeOffset)input).ToString(PlayFabUtil.DefaultDateTimeFormats[PlayFabUtil.DEFAULT_UTC_OUTPUT_INDEX], CultureInfo.InvariantCulture);
                     return true;
                 }
                 else if (input is TimeSpan)

--- a/XamarinTestRunner/XamarinTestRunner/PlayFabSDK/Json/ISerializer.cs
+++ b/XamarinTestRunner/XamarinTestRunner/PlayFabSDK/Json/ISerializer.cs
@@ -71,14 +71,14 @@ namespace PlayFab.Json
                 else if (type == typeof(DateTime))
                 {
                     DateTime output;
-                    var result = DateTime.TryParseExact(valueStr, PlayFabUtil.DefaultDateTimeFormats, CultureInfo.CurrentCulture, _dateTimeStyles, out output);
+                    var result = DateTime.TryParseExact(valueStr, PlayFabUtil.DefaultDateTimeFormats, CultureInfo.InvariantCulture, _dateTimeStyles, out output);
                     if (result)
                         return output;
                 }
                 else if (type == typeof(DateTimeOffset))
                 {
                     DateTimeOffset output;
-                    var result = DateTimeOffset.TryParseExact(valueStr, PlayFabUtil.DefaultDateTimeFormats, CultureInfo.CurrentCulture, _dateTimeStyles, out output);
+                    var result = DateTimeOffset.TryParseExact(valueStr, PlayFabUtil.DefaultDateTimeFormats, CultureInfo.InvariantCulture, _dateTimeStyles, out output);
                     if (result)
                         return output;
                 }
@@ -103,12 +103,12 @@ namespace PlayFab.Json
                 }
                 else if (input is DateTime)
                 {
-                    output = ((DateTime)input).ToString(PlayFabUtil.DefaultDateTimeFormats[PlayFabUtil.DEFAULT_UTC_OUTPUT_INDEX], CultureInfo.CurrentCulture);
+                    output = ((DateTime)input).ToString(PlayFabUtil.DefaultDateTimeFormats[PlayFabUtil.DEFAULT_UTC_OUTPUT_INDEX], CultureInfo.InvariantCulture);
                     return true;
                 }
                 else if (input is DateTimeOffset)
                 {
-                    output = ((DateTimeOffset)input).ToString(PlayFabUtil.DefaultDateTimeFormats[PlayFabUtil.DEFAULT_UTC_OUTPUT_INDEX], CultureInfo.CurrentCulture);
+                    output = ((DateTimeOffset)input).ToString(PlayFabUtil.DefaultDateTimeFormats[PlayFabUtil.DEFAULT_UTC_OUTPUT_INDEX], CultureInfo.InvariantCulture);
                     return true;
                 }
                 else if (input is TimeSpan)


### PR DESCRIPTION
this is so parsing behavior is the same regardless of client lagnuage settings.
For a discussion of the issue view:
https://community.playfab.com/questions/54092/datetime-parsing-wrong-in-c-client-sdk.html?childToView=54202#answer-54202