### PR TITLE
[PluginManager.md]Updating readme to not add an instance name when initializing Polly version of the plugin

### DIFF
--- a/PluginManager.md
+++ b/PluginManager.md
@@ -66,7 +66,7 @@ Then use PluginManager class to set custom plugins before using any other PlayFa
         // will help your services follow better fault tolerance practices 
         // and proper retrying logic against the PlayFab services. For more
         // information, see the PlayFabPollyHttp class summary.
-        PluginManager.SetPlugin(new PlayFabPollyHttp(), PluginContract.PlayFab_Transport, "PluginWithPolly");
+        PluginManager.SetPlugin(new PlayFabPollyHttp(), PluginContract.PlayFab_Transport);
 
         // Optionally set your own custom JSON serializer
         PluginManager.SetPlugin(new MyJsonSerializer(), PluginContract.PlayFab_Serializer);


### PR DESCRIPTION
We need to ensure partners and customers use the correct initialization for the polly version of the transport plugin.