### PR TITLE
Update ValidateEntityTokenAsync to use the instance authenticationContext values

### DIFF
--- a/PlayFabSDK/source/PlayFabAuthenticationInstanceAPI.cs
+++ b/PlayFabSDK/source/PlayFabAuthenticationInstanceAPI.cs
@@ -170,7 +170,7 @@ namespace PlayFab
             var requestContext = request?.AuthenticationContext ?? authenticationContext;
             var requestSettings = apiSettings ?? PlayFabSettings.staticSettings;
 
-            var entityToken = request?.AuthenticationContext?.EntityToken ?? PlayFabSettings.staticPlayer.EntityToken;
+            var entityToken = requestContext?.EntityToken ?? PlayFabSettings.staticPlayer.EntityToken;
             if ((entityToken) == null) throw new PlayFabException(PlayFabExceptionCode.EntityTokenNotSet, "Must call Client Login or GetEntityToken before calling this method");
 
             var httpResult = await PlayFabHttp.DoPost("/Authentication/ValidateEntityToken", request, "X-EntityToken", entityToken, extraHeaders, requestSettings);


### PR DESCRIPTION
## What?
I've added the use of the _requestContext_ local variable that contains the _PlayFabAuthenticationContext_ object.
## Why?
The _PlayFabAuthenticationContext_ instance object isn't used to get the auth context. If we do not pass the auth context in the method request parameters, it does not fall back to use the auth context from the class instance.
## How?
This includes the fix to make use of the previously unused local variable _requestContext_.
