### PR TITLE
Fix CS0619: remove obsolete GetEntityTokenRequest.Entity from UUnit tests

### DIFF
--- a/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
+++ b/PlayFabSDK/source/Uunit/tests/PlayFabServerApiTest.cs
@@ -250,9 +250,6 @@ namespace PlayFab.UUnit
         public async void TestForNotFoundWithImportantInfo(UUnitTestContext testContext)
         {
             var eReq = new AuthenticationModels.GetEntityTokenRequest();
-            eReq.Entity = new AuthenticationModels.EntityKey();
-            eReq.Entity.Type = "title";
-            eReq.Entity.Id = testTitleData.titleId;
 
             var multiApiSettings = new PlayFabApiSettings();
 

--- a/XamarinTestRunner/XamarinTestRunner/PlayFabSDK/Uunit/tests/PlayFabServerApiTest.cs
+++ b/XamarinTestRunner/XamarinTestRunner/PlayFabSDK/Uunit/tests/PlayFabServerApiTest.cs
@@ -250,9 +250,6 @@ namespace PlayFab.UUnit
         public async void TestForNotFoundWithImportantInfo(UUnitTestContext testContext)
         {
             var eReq = new AuthenticationModels.GetEntityTokenRequest();
-            eReq.Entity = new AuthenticationModels.EntityKey();
-            eReq.Entity.Type = "title";
-            eReq.Entity.Id = testTitleData.titleId;
 
             var multiApiSettings = new PlayFabApiSettings();
 


### PR DESCRIPTION
## Problem
 The latest published API spec marks `GetEntityTokenRequest.Entity` as
 `[Obsolete("No longer available", true)]`. After `SDKGenerator` regenerates
 the SDK in the `PlayFab.Publish` pipeline, the hand-written UUnit test
 `PlayFabServerApiTest.cs::TestForNotFoundWithImportantInfo` fails to compile
 with 3× **CS0619** on lines 253–255, breaking both `BuildCSharp` and
 `BuildCSharpBeta` jobs (see build 278788).
 
 ## Fix
 Remove the three `eReq.Entity*` assignments. `GetEntityTokenRequest` now
 derives the entity from the authenticated context (`TitleId` +
 `DeveloperSecretKey` already set on `PlayFabApiSettings` a few lines below).
 
 ## Verification
 - `dotnet build PlayFabSDK/source/PlayFabSDK.csproj` after regenerating
   against fresh `API_Specs/master` → **Build succeeded, 0 Errors**.
 - UUnit suite against a live title: `GetEntityToken` passes; modified test
   runs cleanly past the previously-failing lines.